### PR TITLE
Collections browse

### DIFF
--- a/CollectionTreePlugin.php
+++ b/CollectionTreePlugin.php
@@ -26,7 +26,7 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
         'before_save_collection',
         'after_save_collection',
         'after_delete_collection',
-        'collection_browse_sql',
+        'collections_browse_sql',
         'admin_collections_show',
         'public_collections_show',
     );
@@ -213,20 +213,22 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
     }
 
     /**
-     * Omit all child collections from the collection browse.
+     * Hook for collections browse: omit all child collections from the collection
+     * browse.
      */
-    public function hookCollectionBrowseSql($args)
+    public function hookCollectionsBrowseSql($args)
     {
         if (!is_admin_theme()) {
             $sql = "
-            c.id NOT IN (
+            collections.id NOT IN (
                 SELECT ct.collection_id
                 FROM {$this->_db->CollectionTree} ct
+                WHERE ct.parent_collection_id != 0
             )";
             $args['select']->where($sql);
         }
     }
-    
+
     /**
      * Display the collection's parent collection and child collections.
      */

--- a/CollectionTreePlugin.php
+++ b/CollectionTreePlugin.php
@@ -13,6 +13,9 @@
  */
 class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
 {
+    /**
+     * @var array Hooks for the plugin.
+     */
     protected $_hooks = array(
         'install',
         'uninstall',
@@ -28,10 +31,14 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
         'public_collections_show',
     );
 
+    /**
+     * @var array Filters for the plugin.
+     */
     protected $_filters = array(
         'admin_navigation_main',
         'public_navigation_main',
         'admin_collections_form_tabs',
+        'collections_select_options',
     );
     
     /**
@@ -284,5 +291,18 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
             array('options' => $options, 'parent_collection_id' => $parentCollectionId)
         );
         return $tabs;
+    }
+
+    /**
+     * Manage search options for collections.
+     *
+     * @param array Search options for collections.
+     * @return array Filtered search options for collections.
+     */
+    public function filterCollectionsSelectOptions($options)
+    {
+        $treeOptions = $this->_db->getTable('CollectionTree')->findPairsForSelectForm();
+        // Keep only chosen collections, in case another filter removed some.
+        return array_intersect_key($treeOptions, $options);
     }
 }

--- a/CollectionTreePlugin.php
+++ b/CollectionTreePlugin.php
@@ -46,6 +46,7 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
      */
     protected $_options = array(
         'collection_tree_alpha_order' => 0,
+        'collection_tree_browse_only_root' => 0,
     );
 
     /**
@@ -230,6 +231,9 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
     public function hookCollectionsBrowseSql($args)
     {
         if (!is_admin_theme()) {
+            if (!get_option('collection_tree_browse_only_root')) {
+                return;
+            }
             $sql = "
             collections.id NOT IN (
                 SELECT ct.collection_id

--- a/views/admin/plugins/collection-tree-config-form.php
+++ b/views/admin/plugins/collection-tree-config-form.php
@@ -11,3 +11,15 @@
             array('checked' => (bool) get_option('collection_tree_alpha_order'))); ?>
     </div>
 </div>
+<div class="field">
+    <div class="two columns alpha">
+        <?php echo $this->formLabel('collection_tree_browse_only_root', __('Browse collections')); ?>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation"><?php
+            echo __('The "Browse collections" page can be the normal one or, if checked, limited to root collections.');
+        ?></p>
+        <?php echo $this->formCheckbox('collection_tree_browse_only_root', null,
+            array('checked' => (bool) get_option('collection_tree_browse_only_root'))); ?>
+    </div>
+</div>

--- a/views/admin/plugins/collection-tree-config-form.php
+++ b/views/admin/plugins/collection-tree-config-form.php
@@ -1,11 +1,13 @@
 <div class="field">
-    <div id="collection_tree_alpha_order_label" class="two columns alpha">
-        <label for="collection_tree_alpha_order"><?php echo __('Order alphabetically?'); ?></label>
+    <div class="two columns alpha">
+        <?php echo $this->formLabel('collection_tree_alpha_order', __('Order alphabetically')); ?>
     </div>
     <div class="inputs five columns omega">
-        <p class="explanation"><?php echo __('Order the collection tree alphabetically? ' 
-        . 'This does not affect the order of the collections browse page.'); ?></p>
-        <?php echo $this->formCheckbox('collection_tree_alpha_order', null, 
-        array('checked' => (bool) get_option('collection_tree_alpha_order'))); ?>
+        <p class="explanation"><?php
+            echo __('Order the collection tree alphabetically?');
+            echo __('This does not affect the order of the collections browse page.');
+        ?></p>
+        <?php echo $this->formCheckbox('collection_tree_alpha_order', null,
+            array('checked' => (bool) get_option('collection_tree_alpha_order'))); ?>
     </div>
 </div>


### PR DESCRIPTION
Hi,

I added an option to display only root collections in collections/browse page. Without this patch, this page shows only root collections, instead of all collections.

You can merge in master to get all integrated patches.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
