### PR TITLE
Fixed documentation of a method argument

### DIFF
--- a/models/Table/CollectionTree.php
+++ b/models/Table/CollectionTree.php
@@ -117,8 +117,7 @@ class Table_CollectionTree extends Omeka_Db_Table
     /**
      * Return the collection tree hierarchy as a one-dimensional array.
      *
-     * @param array $options (optional) Set of parameters for searching/
-     * filtering results.
+     * @param array $options (optional) Unused: has no effect whatsoever.
      * @param string $padding The string representation of the collection depth.
      * @return array
      */


### PR DESCRIPTION
Ideally the argument should be removed as it has no use. I've checked and think it's not used anywhere else in the plugin's code; however, it could break BC in the unlikely case that other plugins depending on this one are using this method.