### PR TITLE
Hide orphans and treeview style

### DIFF
--- a/CollectionTreePlugin.php
+++ b/CollectionTreePlugin.php
@@ -50,8 +50,9 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
      */
     protected $_options = array(
         'collection_tree_alpha_order' => 0,
-        'collection_tree_browse_only_root' => 0,
         'collection_tree_show_subcollections' => 0,
+        'collection_tree_hide_orphans' => 0,
+        'collection_tree_browse_only_root' => 0,
         'collection_tree_search_descendant' => 0,
     );
 
@@ -356,10 +357,12 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
     protected function _appendToCollectionsShow($collection)
     {
         $collectionTree = $this->_db->getTable('CollectionTree')->getCollectionTree($collection->id);
-        echo get_view()->partial(
-            'collections/collection-tree-list.php', 
-            array('collection_tree' => $collectionTree)
-        );
+        if (count($collectionTree[0]['children']) > 0 || !get_option('collection_tree_hide_orphans')) {
+            echo get_view()->partial(
+                'collections/collection-tree-list.php', 
+                array('collection_tree' => $collectionTree)
+            );
+        }
     }
     
     /**

--- a/CollectionTreePlugin.php
+++ b/CollectionTreePlugin.php
@@ -32,6 +32,8 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
         'public_items_search',
         'admin_collections_show',
         'public_collections_show',
+        'admin_head',
+        'public_head'
     );
 
     /**
@@ -52,6 +54,7 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
         'collection_tree_alpha_order' => 0,
         'collection_tree_show_subcollections' => 0,
         'collection_tree_hide_orphans' => 0,
+        'collection_tree_treeview_style' => 0,
         'collection_tree_browse_only_root' => 0,
         'collection_tree_search_descendant' => 0,
     );
@@ -364,7 +367,28 @@ class CollectionTreePlugin extends Omeka_Plugin_AbstractPlugin
             );
         }
     }
-    
+
+    /**
+     * Sets css and js in case treeview style is chosen
+     */
+    public function hookPublicHead($args)
+    {
+		if (get_option('collection_tree_treeview_style')) {
+			queue_css_file('file-explore');
+			queue_js_file('file-explore');
+		}
+    }
+
+    /**
+     * Sets css and js in case treeview style is chosen
+     */
+    public function hookAdminHead($args)
+    {
+		if (get_option('collection_tree_treeview_style')) {
+			queue_css_file('file-explore');
+			queue_js_file('file-explore');
+		}
+    }    
     /**
      * Add the collection tree page to the admin navigation.
      */

--- a/views/admin/plugins/collection-tree-config-form.php
+++ b/views/admin/plugins/collection-tree-config-form.php
@@ -1,49 +1,82 @@
+<h2><?php echo __("Appearance"); ?></h2>
+
 <div class="field">
     <div class="two columns alpha">
         <?php echo $this->formLabel('collection_tree_alpha_order', __('Order alphabetically')); ?>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php
-            echo __('Order the collection tree alphabetically?');
-            echo __('This does not affect the order of the collections browse page.');
+            echo __('If checked, the collection tree is ordered alphabetically (does not affect the order of the collections browse page).');
         ?></p>
-        <?php echo $this->formCheckbox('collection_tree_alpha_order', null,
-            array('checked' => (bool) get_option('collection_tree_alpha_order'))); ?>
+        <?php echo $this->formCheckbox(
+            'collection_tree_alpha_order', 
+            null,
+            array('checked' => (bool) get_option('collection_tree_alpha_order'))
+        ); ?>
     </div>
 </div>
-<div class="field">
-    <div class="two columns alpha">
-        <?php echo $this->formLabel('collection_tree_browse_only_root', __('Browse root-level collections only')); ?>
-    </div>
-    <div class="inputs five columns omega">
-        <p class="explanation"><?php
-            echo __('Limit the public collections browse page to root-level collections.');
-        ?></p>
-        <?php echo $this->formCheckbox('collection_tree_browse_only_root', null,
-            array('checked' => (bool) get_option('collection_tree_browse_only_root'))); ?>
-    </div>
-</div>
+
 <div class="field">
     <div class="two columns alpha">
         <?php echo $this->formLabel('collection_tree_show_subcollections', __('Show subcollection items')); ?>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php
-            echo __('On public collection show pages, display items belonging to all subcollections. This is especially useful when root collections are empty and used as main categories.');
+            echo __('If checked, on public collection show pages displays items belonging to all subcollections (especially useful when root collections are empty and used as main categories).');
         ?></p>
-        <?php echo $this->formCheckbox('collection_tree_show_subcollections', null,
-            array('checked' => (bool) get_option('collection_tree_show_subcollections'))); ?>
+        <?php echo $this->formCheckbox(
+            'collection_tree_show_subcollections', 
+            null,
+            array('checked' => (bool) get_option('collection_tree_show_subcollections'))
+        ); ?>
     </div>
 </div>
+
+<div class="field">
+    <div class="two columns alpha">
+        <?php echo $this->formLabel('collection_tree_hide_orphans', __('Hide orphan collections')); ?>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation"><?php
+            echo __('If checked, no collection tree will be shown for collections without parent nor children.');
+        ?></p>
+        <?php echo $this->formCheckbox(
+            'collection_tree_hide_orphans', 
+            null,
+            array('checked' => (bool) get_option('collection_tree_hide_orphans'))
+        ); ?>
+    </div>
+</div>
+
+<h2><?php echo __("Browsing & Searching"); ?></h2>
+<div class="field">
+    <div class="two columns alpha">
+        <?php echo $this->formLabel('collection_tree_browse_only_root', __('Browse root-level collections only')); ?>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation"><?php
+            echo __('If checked, limits the public collections browse page to root-level collections.');
+        ?></p>
+        <?php echo $this->formCheckbox(
+            'collection_tree_browse_only_root', 
+            null,
+            array('checked' => (bool) get_option('collection_tree_browse_only_root'))
+        ); ?>
+    </div>
+</div>
+
 <div class="field">
     <div class="two columns alpha">
         <?php echo $this->formLabel('collection_tree_search_descendant', __('Expand search to subcollection items by default')); ?>
     </div>
     <div class="inputs five columns omega">
         <p class="explanation"><?php
-            echo __('When searching by collection, expand searching to all subcollections by default.');
+            echo __('If checked, expands searching to all subcollections by default when searching by Collection.');
         ?></p>
-        <?php echo $this->formCheckbox('collection_tree_search_descendant', null,
-            array('checked' => (bool) get_option('collection_tree_search_descendant'))); ?>
+        <?php echo $this->formCheckbox(
+            'collection_tree_search_descendant', 
+            null,
+            array('checked' => (bool) get_option('collection_tree_search_descendant'))
+        ); ?>
     </div>
 </div>

--- a/views/admin/plugins/collection-tree-config-form.php
+++ b/views/admin/plugins/collection-tree-config-form.php
@@ -48,7 +48,24 @@
     </div>
 </div>
 
+<div class="field">
+    <div class="two columns alpha">
+        <?php echo $this->formLabel('collection_tree_treeview_style', __('Treeview style')); ?>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation"><?php
+            echo __('If checked, collection trees are displayed in treeview style.');
+        ?></p>
+        <?php echo $this->formCheckbox(
+            'collection_tree_treeview_style', 
+            null,
+            array('checked' => (bool) get_option('collection_tree_treeview_style'))
+        ); ?>
+    </div>
+</div>
+
 <h2><?php echo __("Browsing & Searching"); ?></h2>
+
 <div class="field">
     <div class="two columns alpha">
         <?php echo $this->formLabel('collection_tree_browse_only_root', __('Browse root-level collections only')); ?>

--- a/views/shared/css/file-explore.css
+++ b/views/shared/css/file-explore.css
@@ -1,0 +1,55 @@
+#collection-tree ul {
+	list-style-type: none;
+	font-size: 1em;
+	line-height: 1.8em;
+	margin-top: 0;
+	margin-left: 10px;
+	padding-left: 18px;
+	border-left: 1px dotted #aaa;
+}
+
+#collection-tree li {
+	position: relative;
+}
+
+#collection-tree li a{
+	text-decoration: none;
+	color:#444;
+}
+
+#collection-tree li:before{
+	position: absolute;
+	display: block;
+	content: " ";
+	width: 10px;
+	height: 1px;
+	border-bottom: 1px dotted #aaa;
+	top: .6em;
+	left: -14px;
+}
+
+.collection-tree-icon {
+	display: block;
+	font-family: FontAwesome;
+	font-size: 1.2em;	
+}
+
+.handle:before {
+	margin-right: .2em;
+	content: '\f0f6';
+	float: left;
+}
+
+.collapsed:before {
+	margin-right: .2em;
+	color: #FFD04E;
+	content: "\f07b";
+	cursor: pointer;
+}
+
+.expanded:before {
+	margin-right: .2em;
+	color: #FFD04E;
+	content: "\f07c";
+	cursor: pointer;
+}

--- a/views/shared/index/index.php
+++ b/views/shared/index/index.php
@@ -1,5 +1,6 @@
 <?php echo head(array('title' => __('Collection Tree'))); ?>
 <?php if ($this->full_collection_tree): ?>
+<p><?php echo __('Here\'s a view of the Collections\' tree. Click on any Collection\'s name to open it, and on any folder to expand/contract the tree.'); ?></p>
 <?php echo $this->full_collection_tree; ?>
 <?php else: ?>
 <p><?php echo __('There are no collections.'); ?></p>

--- a/views/shared/javascripts/file-explore.js
+++ b/views/shared/javascripts/file-explore.js
@@ -1,0 +1,18 @@
+jQuery(document).ready(function () {
+	var $ = jQuery;
+
+	init();
+
+	function init() {
+		jQuery("#collection-tree ul:not(:first)").hide();                                                       
+
+		jQuery("#collection-tree li").prepend("<span class='collection-tree-icon handle'></span>");
+
+		jQuery("#collection-tree li:has(ul)")
+			.children(":first-child").addClass("collapsed")
+			.click(function(){    
+				jQuery(this).toggleClass("collapsed expanded")
+					.siblings("ul").toggle();
+			});       
+	}
+});


### PR DESCRIPTION
Hi.

I've added two new options to the plugin:
- hide orphan collections: a chance to hide the collection tree on Admin and Public side if the collection has neither parent nor children;
- treeview style: option to display the collections in a graphical, treeview style instead of the default unordered lists.

Hope this helps.